### PR TITLE
Kept getting "TypeError: Data must not be unicode" error message while sending a message from the client UI.

### DIFF
--- a/4_Chat/main.py
+++ b/4_Chat/main.py
@@ -50,7 +50,7 @@ class ChatApp(App):
         self.conn.write('%s:%s' % (self.nick, msg))
         self.root.ids.chat_logs.text += (
             '[b][color=2980b9]{}:[/color][/b] {}\n'
-            .format(self.nick, esc_markup(msg)))
+            .format(self.nick.encode('utf8'), esc_markup(msg).encode('utf8')))
         self.root.ids.message.text = ''
 
     def on_connect(self, conn):


### PR DESCRIPTION
It seems that twisted is not so friendly with unicode objects. This fix stopped the error. For further information on this error, visit http://twistedmatrix.com/trac/wiki/FrequentlyAskedQuestions#WhydontTwistedsnetworkmethodssupportUnicodeobjectsaswellasstrings
