### PR TITLE
add line feed to the 'CONNECT' message to force TCP flush

### DIFF
--- a/4_Chat/main.py
+++ b/4_Chat/main.py
@@ -15,7 +15,9 @@ def esc_markup(msg):
 
 class ChatClient(protocol.Protocol):
     def connectionMade(self):
-        self.transport.write('CONNECT')
+        # send 'CONNECT' message and 
+        # force TCP flush by appending a line feed ('\n')
+        self.transport.write('CONNECT\n')
         self.factory.app.on_connect(self.transport)
 
     def dataReceived(self, data):


### PR DESCRIPTION
If no line feed is appended when the 'CONNECT' message is issued, then there is a non deterministic behaviour regarding the actual transmission of the message to the server.

For example, on my windows machine, (python 2.7 twisted 16), the actual transmission of the 'CONNECT' message is delayed until a first message is sent to the server while on a raspberry the 'CONNECT' message is immediately sent through the TCP socket even if it does not terminate with a line feed.
